### PR TITLE
feature: Enable user-side configuration of xlink:href resolving

### DIFF
--- a/ui_wfsclientconfig.ui
+++ b/ui_wfsclientconfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>541</width>
-    <height>399</height>
+    <height>443</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <property name="geometry">
     <rect>
      <x>370</x>
-     <y>370</y>
+     <y>410</y>
      <width>161</width>
      <height>23</height>
     </rect>
@@ -35,7 +35,7 @@
      <x>10</x>
      <y>10</y>
      <width>521</width>
-     <height>131</height>
+     <height>171</height>
     </rect>
    </property>
    <property name="frameShape">
@@ -48,7 +48,7 @@
     <property name="geometry">
      <rect>
       <x>290</x>
-      <y>70</y>
+      <y>110</y>
       <width>21</width>
       <height>20</height>
      </rect>
@@ -67,7 +67,7 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>70</y>
+      <y>110</y>
       <width>261</width>
       <height>16</height>
      </rect>
@@ -146,7 +146,7 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>100</y>
+      <y>140</y>
       <width>261</width>
       <height>16</height>
      </rect>
@@ -166,7 +166,7 @@
     <property name="geometry">
      <rect>
       <x>290</x>
-      <y>100</y>
+      <y>140</y>
       <width>21</width>
       <height>20</height>
      </rect>
@@ -184,6 +184,55 @@
      <bool>false</bool>
     </property>
    </widget>
+   <widget class="QComboBox" name="cmbGmlSkipResolveElems">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>70</y>
+      <width>91</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="editable">
+     <bool>true</bool>
+    </property>
+    <item>
+     <property name="text">
+      <string>NONE</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>HUGE</string>
+     </property>
+    </item>
+   </widget>
+   <widget class="QLabel" name="lblGmlSkipResolveElems">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>70</y>
+      <width>261</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>8</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>Resolve method (&lt;a href=&quot;https://gdal.org/drivers/vector/gml.html#gml-xlink-resolving&quot;&gt;GML_SKIP_RESOLVE_ELEMS&lt;/a&gt;)</string>
+    </property>
+   </widget>
    <zorder>lblAttributesToFields</zorder>
    <zorder>lblResolveXlinkHref</zorder>
    <zorder>lblGmlHeader</zorder>
@@ -191,12 +240,14 @@
    <zorder>chkResolveXlinkHref</zorder>
    <zorder>lblDisableNasDetection</zorder>
    <zorder>chkDisableNasDetection</zorder>
+   <zorder>cmbGmlSkipResolveElems</zorder>
+   <zorder>lblGmlSkipResolveElems</zorder>
   </widget>
   <widget class="QFrame" name="frmWfs">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>150</y>
+     <y>190</y>
      <width>521</width>
      <height>211</height>
     </rect>

--- a/wfsclientconfigdialog.py
+++ b/wfsclientconfigdialog.py
@@ -37,6 +37,7 @@ class WfsClientConfigDialog(QtWidgets.QDialog):
 
         #Restore UI from Settings
         resolvexlinkhref = self.settings.value("/Wfs20Client/resolveXpathHref")
+        gmlskipresolveelems = self.settings.value("/Wfs20Client/gmlSkipResolveElems")
         attributestofields = self.settings.value("/Wfs20Client/attributesToFields")
         disablenasdetection = self.settings.value("/Wfs20Client/disableNasDetection")
         resolvedepth = self.settings.value("/Wfs20Client/resolveDepth")
@@ -46,10 +47,17 @@ class WfsClientConfigDialog(QtWidgets.QDialog):
         index = self.ui.cmbResolveDepth.findText(resolvedepth)
         self.ui.cmbResolveDepth.setCurrentIndex(index)
 
+
         if resolvexlinkhref is True or resolvexlinkhref == "true":
             self.ui.chkResolveXlinkHref.setChecked(True)
+            if gmlskipresolveelems is None:
+                gmlskipresolveelems = "HUGE"
         else:
             self.ui.chkResolveXlinkHref.setChecked(False)
+
+        if gmlskipresolveelems == "NONE" or gmlskipresolveelems == "HUGE":
+            index = self.ui.cmbGmlSkipResolveElems.findText(gmlskipresolveelems)
+            self.ui.cmbGmlSkipResolveElems.setCurrentIndex(index)
 
         if attributestofields is True or attributestofields == "true":
             self.ui.chkAttributesToFields.setChecked(True)
@@ -70,12 +78,19 @@ class WfsClientConfigDialog(QtWidgets.QDialog):
             self.ui.txtFeatureLimit.setText(defaultfeaturelimit)
 
         self.ui.cmdSaveConfig.clicked.connect(self.save_config)
+        self.ui.chkResolveXlinkHref.stateChanged.connect(self.manage_resolve_method)
+
+        self.manage_resolve_method(self.ui.chkResolveXlinkHref.isChecked())
 
 
 
     def save_config(self):
         # Save Settings
         self.settings.setValue("/Wfs20Client/resolveXpathHref", self.ui.chkResolveXlinkHref.isChecked())
+        if not self.ui.chkResolveXlinkHref.isChecked():
+            self.settings.setValue("/Wfs20Client/gmlSkipResolveElems", "ALL")
+        else:
+            self.settings.setValue("/Wfs20Client/gmlSkipResolveElems", self.ui.cmbGmlSkipResolveElems.currentText())
         self.settings.setValue("/Wfs20Client/attributesToFields", self.ui.chkAttributesToFields.isChecked())
         self.settings.setValue("/Wfs20Client/disableNasDetection", self.ui.chkDisableNasDetection.isChecked())
         self.settings.setValue("/Wfs20Client/resolveDepth", self.ui.cmbResolveDepth.currentText())
@@ -83,3 +98,10 @@ class WfsClientConfigDialog(QtWidgets.QDialog):
         self.settings.setValue("/Wfs20Client/defaultFeatureLimit", self.ui.txtFeatureLimit.text().strip())
         QtWidgets.QMessageBox.information(self, "Information", "Configuration saved!")
         self.close()
+
+
+
+    def manage_resolve_method(self, enabled):
+        # enable/disable resolve method combo and associated label
+        self.ui.cmbGmlSkipResolveElems.setEnabled(enabled)
+        self.ui.lblGmlSkipResolveElems.setEnabled(enabled)

--- a/wfsclientdialog.py
+++ b/wfsclientdialog.py
@@ -999,17 +999,19 @@ class WfsClientDialog(QtWidgets.QDialog):
 
         # Configure OGR/GDAL GML-Driver
         resolvexlinkhref = self.settings.value("/Wfs20Client/resolveXpathHref")
+        gmlskipresolveelems = self.settings.value("/Wfs20Client/gmlSkipResolveElems")
+        if not(resolvexlinkhref is True or resolvexlinkhref == "true"):
+            gmlskipresolveelems = 'ALL'
+        elif not(gmlskipresolveelems == 'NONE' or gmlskipresolveelems == 'HUGE'):
+            gmlskipresolveelems = 'HUGE'
         attributestofields = self.settings.value("/Wfs20Client/attributesToFields")
         disablenasdetection = self.settings.value("/Wfs20Client/disableNasDetection")
 
         gdaltimeout = "5"
         self.logger.debug("GDAL_HTTP_TIMEOUT " + gdaltimeout)
         gdal.SetConfigOption("GDAL_HTTP_TIMEOUT", gdaltimeout)
-        if resolvexlinkhref is True or resolvexlinkhref == "true":
-            gdal.SetConfigOption('GML_SKIP_RESOLVE_ELEMS', 'HUGE')
-            self.logger.debug("resolveXpathHref " + str(resolvexlinkhref))
-        else:
-            gdal.SetConfigOption('GML_SKIP_RESOLVE_ELEMS', 'ALL')
+        self.logger.debug("GML_SKIP_RESOLVE_ELEMS " + gmlskipresolveelems)
+        gdal.SetConfigOption('GML_SKIP_RESOLVE_ELEMS', gmlskipresolveelems)
 
         if attributestofields is True or attributestofields == "true":
             gdal.SetConfigOption('GML_ATTRIBUTES_TO_OGR_FIELDS', 'YES')


### PR DESCRIPTION
 * Due to #19 the GDAL-configuration GML_SKIP_RESOLVE_ELEMS was set to HUGE
   when the user requests resolving of xlink:href (previously NONE).
 * This change is presumably the reason for problems reported resolving in #25.
 * Since probably not everyone will be satisified with one or other of the
   options then the user should be able to choose which to use once
   resolving of xlink:href is activated, thus removing the need for the devloper
   to decide which option to use and passing this decision to the user.
 * The default GML_SKIP_RESOLVE_ELEMS is maintained as HUGE.